### PR TITLE
Add Slack posting support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ python footballer_app.py "How is Bukayo Saka performing this season?" --model gp
 ```
 
 The tool prints the model's response directly to standard output.
+
+## Sending results to Slack (#general in markdias workspace)
+
+You can optionally forward the generated scouting report to your Slack workspace.
+Create a bot token in the **markdias** workspace with the `chat:write`
+permission and export it as an environment variable:
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-your-token"
+```
+
+When you run the CLI, supply the target channel (for example `#general`) and the
+tool will post the message after printing it locally:
+
+```bash
+python footballer_app.py "Update me on Trinity Rodman's recent performances" \
+  --slack-channel "#general"
+```
+
+Alternatively, you can provide the token inline with `--slack-token` if you do
+not want to rely on an environment variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai>=1.30.0
 python-dotenv>=1.0.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add optional Slack posting support so CLI responses can be sent to #general in the markdias workspace
- document how to configure Slack credentials and invoke the new flags
- include the requests dependency required for Slack API calls

## Testing
- python -m compileall footballer_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e58a219cbc832e9ac06b9b4ecb2567