### PR TITLE
Add career history table support to footballer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ python footballer_app.py "How is Bukayo Saka performing this season?" --model gp
 
 The tool prints the model's response directly to standard output.
 
+### Career-history tables
+
+If you simply pass a player's name (for example `"Sophia Smith"`), the tool will
+automatically request their club and international career history formatted as a
+chronological Markdown table. You can explicitly control this behaviour:
+
+```bash
+# Force the table output regardless of the query phrasing
+python footballer_app.py "Lionel Messi scouting report" --career-table
+
+# Opt out of the automatic table when you just want narrative analysis
+python footballer_app.py "Ada Hegerberg" --no-career-table
+```
+
 ## Sending results to Slack (#general in markdias workspace)
 
 You can optionally forward the generated scouting report to your Slack workspace.

--- a/footballer_app.py
+++ b/footballer_app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from typing import Optional
 
@@ -55,7 +56,13 @@ def send_slack_message(message: str, *, token: str, channel: str) -> None:
         raise SlackPostError(f"Slack API error: {error}")
 
 
-def fetch_footballer_info(query: str, *, model: str = "gpt-4.1-mini", temperature: float = 0.3) -> str:
+def fetch_footballer_info(
+    query: str,
+    *,
+    model: str = "gpt-4.1-mini",
+    temperature: float = 0.3,
+    career_table: bool = False,
+) -> str:
     """Fetch information about a footballer using the OpenAI Responses API.
 
     Args:
@@ -71,12 +78,23 @@ def fetch_footballer_info(query: str, *, model: str = "gpt-4.1-mini", temperatur
     """
 
     client = OpenAI()
+    user_message = query
+    if career_table:
+        user_message = (
+            f"{query}\n\n"
+            "Return the player's professional career history as a chronological "
+            "Markdown table. Include club and national-team stints with columns for "
+            "Years, Team, Competition/League, Appearances, Goals, and Notes. Use "
+            "'N/A' when figures are unavailable and add any important context below "
+            "the table."
+        )
+
     response = client.responses.create(
         model=model,
         temperature=temperature,
         input=[
             {"role": "system", "content": _SYSTEM_PROMPT},
-            {"role": "user", "content": query},
+            {"role": "user", "content": user_message},
         ],
     )
     return response.output_text.strip()
@@ -97,6 +115,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Sampling temperature (default: %(default)s).",
     )
     parser.add_argument(
+        "--career-table",
+        dest="career_table",
+        action="store_true",
+        default=None,
+        help="Force the response to be formatted as a career history table.",
+    )
+    parser.add_argument(
+        "--no-career-table",
+        dest="career_table",
+        action="store_false",
+        help="Disable the automatic career history table formatting.",
+    )
+    parser.add_argument(
         "--slack-channel",
         help="Slack channel (e.g., #general) to post the response to.",
     )
@@ -107,15 +138,49 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+_NAME_CHARS = re.compile(r"^[A-Za-z .'-]+$")
+
+
+def _looks_like_player_name(text: str) -> bool:
+    """Heuristically determine whether the query is just a player's name."""
+
+    stripped = text.strip()
+    if not stripped:
+        return False
+
+    # Quickly discard anything that looks like a question or command.
+    if any(punct in stripped for punct in "?!"):
+        return False
+
+    if not _NAME_CHARS.match(stripped):
+        return False
+
+    tokens = stripped.split()
+    if len(tokens) > 6:
+        return False
+
+    # Avoid common prompt starters that would otherwise match the regex.
+    lower_first = tokens[0].lower()
+    if lower_first in {"tell", "show", "give", "provide"}:
+        return False
+
+    return True
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    career_table = args.career_table
+    if career_table is None:
+        career_table = _looks_like_player_name(args.query)
 
     try:
         response = fetch_footballer_info(
             args.query,
             model=args.model,
             temperature=args.temperature,
+            career_table=career_table,
         )
     except OpenAIError as exc:  # pragma: no cover - depends on external service
         parser.error(f"OpenAI API request failed: {exc}")


### PR DESCRIPTION
## Summary
- add a career-table option to the CLI that instructs the model to return a chronological Markdown table
- automatically enable the table formatting when the query looks like just a player name and document the behaviour in the README

## Testing
- not run (explanation: no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68e58e188b94832e9680136dbd2e508a