### PR TITLE
Replace deprecated imghdr usage

### DIFF
--- a/tests/test_image_detection.py
+++ b/tests/test_image_detection.py
@@ -1,0 +1,14 @@
+"""Tests for image type detection helper."""
+
+from footballer_app import _detect_image_type
+
+
+def test_detects_common_signatures():
+    assert _detect_image_type(b"\xFF\xD8\xFF\xE0rest") == "JPEG"
+    assert _detect_image_type(b"\x89PNG\r\n\x1a\nrest") == "PNG"
+    assert _detect_image_type(b"GIF89a...") == "GIF"
+    assert _detect_image_type(b"RIFF1234WEBPmore") == "WEBP"
+
+
+def test_unknown_signature_returns_none():
+    assert _detect_image_type(b"notanimage") is None


### PR DESCRIPTION
## Summary
- add a lightweight image signature detector to replace the removed `imghdr` module
- update image downloading to use the new helper and keep returning uppercase types
- add unit tests covering the detection helper for common formats and unknown data

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e597dd0048832eb70133aa11aaf9c1