### PR TITLE
Add follow-up question and teammate guidance to system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This repository contains a small Python command-line tool that sends your
 queries about footballers (soccer players) to OpenAI's GPT models. It is useful
 for gathering quick scouting reports, background information, and notable
-statistics for players you're interested in.
+statistics for players you're interested in. Responses now wrap up with two
+follow-up questions about the subject and highlight a teammate who has played
+with them.
 
 ## Getting started
 

--- a/footballer_app.py
+++ b/footballer_app.py
@@ -47,7 +47,9 @@ _SYSTEM_PROMPT = (
     "You are an expert football analyst. Provide detailed, factual information "
     "about footballers, including career highlights, statistics, playing style, "
     "and notable achievements. Mention sources when relevant and clarify "
-    "uncertainties."
+    "uncertainties. After sharing the requested analysis, ask the user two "
+    "relevant follow-up questions about the player and identify at least one "
+    "other player who has played with them, explaining when they were teammates."
 )
 
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,10 @@
+"""Tests related to the system prompt behaviour."""
+
+from footballer_app import _SYSTEM_PROMPT
+
+
+def test_system_prompt_mentions_follow_up_questions() -> None:
+    """The system prompt should instruct follow-up questions and teammate lookup."""
+
+    assert "follow-up" in _SYSTEM_PROMPT
+    assert "played with" in _SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- expand the system prompt so the assistant always asks two follow-up questions and highlights a teammate who has played with the subject
- document the new behaviour in the README for the CLI
- add a regression test to ensure the system prompt retains the follow-up and teammate instructions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6c8110be8832eb8b3f18d7d726f52