### PR TITLE
Add interactive question selection menu to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Optional flags let you customize the model and sampling temperature:
 python footballer_app.py "How is Bukayo Saka performing this season?" --model gpt-4.1 --temperature 0.4
 ```
 
+### Interactive question menu
+
+If you're not sure what to ask, you can launch an interactive menu of sample
+queries. The tool will list several ready-made scouting prompts and send the
+selected one to the API:
+
+```bash
+python footballer_app.py --menu
+```
+
 The tool prints the model's response directly to standard output. When a
 career-history table is present, it is re-rendered with pandas so the columns
 line up neatly in your terminal.

--- a/tests/test_question_menu.py
+++ b/tests/test_question_menu.py
@@ -1,0 +1,53 @@
+"""Tests for the interactive question menu helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from footballer_app import MenuSelectionCancelled, _select_question_from_menu
+
+
+def test_select_question_from_menu_returns_selected_question() -> None:
+    """The helper should return the question corresponding to the chosen index."""
+
+    prompts = iter(["2"])
+    outputs: list[str] = []
+
+    result = _select_question_from_menu(
+        ["First question", "Second question", "Third question"],
+        input_fn=lambda _: next(prompts),
+        print_fn=outputs.append,
+    )
+
+    assert result == "Second question"
+    assert any(line.startswith("1.") for line in outputs)
+
+
+def test_select_question_from_menu_retries_invalid_input() -> None:
+    """Invalid selections should prompt the user again until a valid choice is made."""
+
+    prompts = iter(["invalid", "4", "1"])
+    outputs: list[str] = []
+
+    result = _select_question_from_menu(
+        ["Only option"],
+        input_fn=lambda _: next(prompts),
+        print_fn=outputs.append,
+    )
+
+    assert result == "Only option"
+    assert any("not a valid selection" in line for line in outputs)
+
+
+def test_select_question_from_menu_cancel() -> None:
+    """Entering 'q' should cancel the menu and raise a specific exception."""
+
+    with pytest.raises(MenuSelectionCancelled):
+        _select_question_from_menu(["Question"], input_fn=lambda _: "q", print_fn=lambda _: None)
+
+
+def test_select_question_from_menu_requires_questions() -> None:
+    """Providing an empty sequence should raise ValueError."""
+
+    with pytest.raises(ValueError):
+        _select_question_from_menu([], input_fn=lambda _: "1", print_fn=lambda _: None)


### PR DESCRIPTION
## Summary
- add an interactive menu so the CLI can provide sample questions when `--menu` is used
- ensure the positional query is optional and gracefully handles menu cancellation
- document the new workflow and add unit tests covering the menu helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6cfd56aec832ebe44d32fa0ea156f